### PR TITLE
[scheduler:api] Add endpoint to get list of tasks and related info

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -351,6 +351,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.6.0"
+description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "django_cors_headers-4.6.0-py3-none-any.whl", hash = "sha256:8edbc0497e611c24d5150e0055d3b178c6534b8ed826fb6f53b21c63f5d48ba3"},
+    {file = "django_cors_headers-4.6.0.tar.gz", hash = "sha256:14d76b4b4c8d39375baeddd89e4f08899051eeaf177cb02a29bd6eae8cf63aa8"},
+]
+
+[package.dependencies]
+asgiref = ">=3.6"
+django = ">=4.2"
+
+[[package]]
 name = "django-rq"
 version = "2.10.2"
 description = "An app that provides django integration for RQ (Redis Queue)"
@@ -369,6 +384,20 @@ rq = ">=1.14"
 [package.extras]
 sentry = ["raven (>=6.1.0)"]
 testing = ["mock (>=2.0.0)"]
+
+[[package]]
+name = "djangorestframework"
+version = "3.15.2"
+description = "Web APIs for Django, made easy."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20"},
+    {file = "djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad"},
+]
+
+[package.dependencies]
+django = ">=4.2"
 
 [[package]]
 name = "dulwich"
@@ -834,4 +863,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b396c51e1014392cf1203eeb44799fd49ff70bf11724a128fbf71426c36b9383"
+content-hash = "a55cdfda9bca58b26a880805697a9fef438c16d8aaa766141d30d35fe4777afa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ grimoirelab-toolkit = {version = "^1.0.2", allow-prereleases = true}
 perceval = {version = "^1.0.2", allow-prereleases = true}
 # TODO: Change chronicler to package
 grimoirelab-chronicler = {git = "https://github.com/grimoirelab/grimoirelab-chronicler.git", allow-prereleases = true}
+django-cors-headers = "^4.6.0"
+djangorestframework = "^3.15.2"
 
 [tool.poetry.group.dev.dependencies]
 fakeredis = "^2.0.0"

--- a/src/grimoirelab/core/config/settings.py
+++ b/src/grimoirelab/core/config/settings.py
@@ -285,7 +285,8 @@ RQ_QUEUES = {
 }
 
 RQ = {
-    'JOB_CLASS': 'grimoirelab.core.scheduler.jobs.GrimoireLabJob'
+    'JOB_CLASS': 'grimoirelab.core.scheduler.jobs.GrimoireLabJob',
+    'WORKER_CLASS': 'grimoirelab.core.scheduler.worker.GrimoireLabWorker',
 }
 
 #

--- a/src/grimoirelab/core/config/settings.py
+++ b/src/grimoirelab/core/config/settings.py
@@ -51,6 +51,28 @@ else:
     ]
 
 #
+# Cross-Origin Resource Sharing (CORS)
+#
+# You'll HAVE TO configure the origins that are authorized to make
+# cross-site HTTP requests. Check the following link to understand
+# the possibilities and parameters you can use.
+#
+# https://github.com/adamchainz/django-cors-headers#configuration
+#
+
+if 'GRIMOIRELAB_CORS_ALLOWED_ORIGINS' in os.environ:
+    CORS_ALLOWED_ORIGINS = os.environ['GRIMOIRELAB_CORS_ALLOWED_ORIGINS'].split(',')
+elif 'GRIMOIRELAB_CORS_ALLOWED_ORIGIN_REGEXES' in os.environ:
+    CORS_ALLOWED_ORIGIN_REGEXES = os.environ['GRIMOIRELAB_CORS_ALLOWED_ORIGIN_REGEXES'].split(',')
+else:
+    CORS_ALLOWED_ORIGINS = [
+        'http://localhost:5173',
+    ]
+
+CORS_ALLOW_CREDENTIALS = True
+
+
+#
 # The secret key must be a large random value and it must be kept secret.
 #
 # https://docs.djangoproject.com/en/4.2/ref/settings/#secret-key
@@ -70,11 +92,14 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_rq',
+    'corsheaders',
+    'rest_framework',
     'grimoirelab.core.scheduler',
     'grimoirelab.core.scheduler.tasks',
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -218,6 +243,15 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Django REST Framework settings
+
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 100
+}
 
 #
 # GrimoireLab uses RQ to run background and async jobs.

--- a/src/grimoirelab/core/scheduler/api.py
+++ b/src/grimoirelab/core/scheduler/api.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) GrimoireLab Contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from rest_framework import (
+    generics,
+    pagination,
+    response,
+    serializers,
+)
+
+from .tasks.models import EventizerTask
+
+
+class EventizerTaskPaginator(pagination.PageNumberPagination):
+    page_size = 25
+    page_size_query_param = 'size'
+    max_page_size = 100
+
+    def get_paginated_response(self, data):
+        return response.Response({
+            'links': {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link()
+            },
+            'count': self.page.paginator.count,
+            'page': self.page.number,
+            'total_pages': self.page.paginator.num_pages,
+            'results': data
+        })
+
+
+class EventizerTaskListSerializer(serializers.ModelSerializer):
+    status = serializers.CharField(source='get_status_display')
+
+    class Meta:
+        model = EventizerTask
+        fields = [
+            'uuid', 'status', 'runs', 'failures', 'last_run',
+            'scheduled_at', 'datasource_type', 'datasource_category',
+        ]
+
+
+class EventizerTaskList(generics.ListCreateAPIView):
+    queryset = EventizerTask.objects.all()
+    serializer_class = EventizerTaskListSerializer
+    pagination_class = EventizerTaskPaginator

--- a/src/grimoirelab/core/scheduler/urls.py
+++ b/src/grimoirelab/core/scheduler/urls.py
@@ -18,8 +18,11 @@
 
 from django.urls import re_path
 
+from . import api
 from . import views
+
 
 urlpatterns = [
     re_path(r'^add_task', views.add_task),
+    re_path(r'^tasks/', api.EventizerTaskList.as_view()),
 ]

--- a/src/grimoirelab/core/scheduler/urls.py
+++ b/src/grimoirelab/core/scheduler/urls.py
@@ -16,7 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-from django.urls import re_path
+from django.urls import path, re_path
 
 from . import api
 from . import views
@@ -24,5 +24,9 @@ from . import views
 
 urlpatterns = [
     re_path(r'^add_task', views.add_task),
-    re_path(r'^tasks/', api.EventizerTaskList.as_view()),
+    path('tasks/', api.EventizerTaskList.as_view()),
+    path('tasks/<str:uuid>/', api.EventizerTaskDetail.as_view()),
+    path('tasks/<str:task_id>/jobs/', api.EventizerJobList.as_view()),
+    path('tasks/<str:task_id>/jobs/<str:uuid>/', api.EventizerJobDetail.as_view()),
+    path('tasks/<str:task_id>/jobs/<str:uuid>/logs/', api.EventizerJobLogs.as_view()),
 ]

--- a/src/grimoirelab/core/scheduler/worker.py
+++ b/src/grimoirelab/core/scheduler/worker.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) GrimoireLab Contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+import logging
+import typing
+
+import django.db.transaction
+import rq.worker
+
+from .db import find_job
+from .models import SchedulerStatus
+
+if typing.TYPE_CHECKING:
+    from .jobs import GrimoireLabJob
+
+
+logger = logging.getLogger(__name__)
+
+
+class GrimoireLabWorker(rq.worker.Worker):
+    """Worker to run GrimoireLab jobs.
+
+    This class includes some extra functionality to run GrimoireLab
+    jobs, like for example, update Job status on models.
+    """
+    def prepare_job_execution(self, job: GrimoireLabJob, remove_from_intermediate_queue: bool = False):
+        """Performs bookkeeping like updating states prior to job execution."""
+
+        super().prepare_job_execution(job, remove_from_intermediate_queue)
+
+        job_db = find_job(job.id)
+
+        with django.db.transaction.atomic():
+            job_db.status = SchedulerStatus.RUNNING
+            job_db.save()
+            job_db.task.status = SchedulerStatus.RUNNING
+            job_db.task.save()


### PR DESCRIPTION
The new endpoints allows to get the list of tasks and jobs scheduled on the platform.

To implement this, we have added Django REST Framework library which provides nice stuff to add pagination, serialization, and others easily.

Django CORS Headers library was also added to deal with CORS issues.

The endpoints are:

- `/scheduler/tasks`: list of tasks
- `/scheduler/tasks/<uuid>/`: details of the requested task
- `/scheduler/tasks/<task_uuid>/jobs/`: jobs of the requested task
- `/scheduler/tasks/<task_uuid>/jobs/<uuid>/`: details of the requested job
- `/scheduler/tasks/<task_uuid>/jobs/<uuid>/logs/`: logs of the requested job