### PR TITLE
Fix date parsing error when re-scheduling

### DIFF
--- a/src/grimoirelab/core/scheduler/tasks/chronicler.py
+++ b/src/grimoirelab/core/scheduler/tasks/chronicler.py
@@ -28,7 +28,7 @@ import perceval.backend
 import perceval.backends
 import chronicler.eventizer
 
-from grimoirelab_toolkit.datetime import unixtime_to_datetime
+from grimoirelab_toolkit.datetime import str_to_datetime
 
 from ...scheduler.errors import NotFoundError
 
@@ -124,10 +124,8 @@ class ChroniclerProgress:
     def from_dict(cls, data: dict[str, Any]) -> ChroniclerProgress:
         """Create a new instance from a dictionary."""
 
-        def convert_to_datetime(unixtime: str) -> datetime | None:
-            if unixtime:
-                return unixtime_to_datetime(unixtime)
-            return None
+        def convert_to_datetime(dt: str) -> datetime | None:
+            return str_to_datetime(dt) if dt else None
 
         data_summary = data['summary']
 

--- a/tests/scheduler/test_task_eventizer.py
+++ b/tests/scheduler/test_task_eventizer.py
@@ -221,9 +221,9 @@ class TestChroniclerProgress(GrimoireLabTestCase):
             'summary': {
                 'fetched': 10,
                 'skipped': 2,
-                'min_updated_on': 1609459200.0,  # 2021-01-01
-                'max_updated_on': 1609545600.0,  # 2021-01-02
-                'last_updated_on': 1609632000.0,  # 2021-01-03
+                'min_updated_on': '2021-01-01 00:00:0+00:00',
+                'max_updated_on': '2021-01-02 00:00:0+00:00',
+                'last_updated_on': '2021-01-03 00:00:0+00:00',
                 'last_uuid': 'abc123',
                 'min_offset': 1,
                 'max_offset': 10,


### PR DESCRIPTION
This bug raise when the job was re-scheduled. The progress object stores the dates as 'YYYY-MM-DD' strings but the scheduler was trying to convert unix time dates to datetime.