### PR TITLE
Update task api

### DIFF
--- a/src/grimoirelab/core/scheduler/views.py
+++ b/src/grimoirelab/core/scheduler/views.py
@@ -37,8 +37,8 @@ def add_task(request):
     {
         'type': 'eventizer',
         'task_args': {
-            'backend": 'git',
-            'category": 'commit',
+            'datasource_type': 'git',
+            'datasource_category': 'commit',
             'backend_args': {
                 'uri': 'https://github.com/chaoss/grimoirelab.git'
             }
@@ -67,8 +67,8 @@ def add_task(request):
 
     task = schedule_task(
         task_type, task_args,
-        datasource_type=data['task_args']['backend'],
-        datasource_category=data['task_args']['category'],
+        datasource_type=data['task_args']['datasource_type'],
+        datasource_category=data['task_args']['datasource_category'],
         job_interval=job_interval,
         job_max_retries=job_max_retries
     )


### PR DESCRIPTION
This PR introduces two changes in the API:

- Parameters `backend` and `category` have been renamed to 'datasource_type' and `datasource_category` on `add_task`  endpoint.
- Data returned by the task list includes the new field `last_jobs`, which includes the data of the last 10 jobs run by a task.