### PR TITLE
[permissions] Add permission groups management

### DIFF
--- a/src/grimoirelab/core/config/permission_groups.json
+++ b/src/grimoirelab/core/config/permission_groups.json
@@ -1,0 +1,31 @@
+{
+  "groups": {
+    "admin": {
+      "datasources": {
+        "repository": ["add", "change", "delete", "view"]
+      },
+      "tasks": {
+        "eventizerjob": ["add", "change", "delete", "view"],
+        "eventizertask": ["add", "change", "delete", "view"]
+      }
+    },
+    "user": {
+      "datasources": {
+        "repository": ["add", "change", "delete", "view"]
+      },
+      "tasks": {
+        "eventizerjob": ["add", "change", "delete", "view"],
+        "eventizertask": ["add", "change", "delete", "view"]
+      }
+    },
+    "readonly": {
+      "datasources": {
+        "repository": ["view"]
+      },
+      "tasks": {
+        "eventizerjob": ["view"],
+        "eventizertask": ["view"]
+      }
+    }
+  }
+}

--- a/src/grimoirelab/core/config/settings.py
+++ b/src/grimoirelab/core/config/settings.py
@@ -275,6 +275,15 @@ REST_FRAMEWORK = {
 }
 
 #
+# Path of the permission groups configuration file
+#
+# https://docs.djangoproject.com/en/4.2/topics/auth/default/#groups
+#
+
+PERMISSION_GROUPS_LIST_PATH = os.environ.get('GRIMOIRELAB_PERMISSION_GROUPS_LIST_PATH',
+                                            os.path.join(BASE_DIR, 'config', 'permission_groups.json'))
+
+#
 # GrimoireLab uses RQ to run background and async jobs.
 # You'll HAVE TO set the next parameters in order to run
 # them in the background.

--- a/src/grimoirelab/core/datasources/views.py
+++ b/src/grimoirelab/core/datasources/views.py
@@ -22,10 +22,12 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 
 from .models import Repository
-from grimoirelab.core.scheduler.scheduler import schedule_task
+from ..scheduler.scheduler import schedule_task
+from ..permissions import check_permissions
 
 
 @api_view(['POST'])
+@check_permissions(['datasources.add_repository'])
 def add_repository(request):
     """Create a Repository and start a Task to fetch items
 

--- a/src/grimoirelab/core/permissions.py
+++ b/src/grimoirelab/core/permissions.py
@@ -18,6 +18,7 @@
 
 from django.conf import settings
 from rest_framework.permissions import BasePermission
+from rest_framework.response import Response
 
 
 class IsAuthenticated(BasePermission):
@@ -30,3 +31,19 @@ class IsAuthenticated(BasePermission):
             return True
 
         return bool(request.user and request.user.is_authenticated)
+
+
+def check_permissions(permissions):
+    """
+    Decorator to check if the user has the given permissions.
+    This only works for RestFramework views.
+    """
+    def decorator(func):
+        def wrapper(request, *args, **kwargs):
+            if not settings.GRIMOIRELAB_AUTHENTICATION_REQUIRED:
+                return func(request, *args, **kwargs)
+            if not request.user or not request.user.has_perms(permissions):
+                return Response({'message': 'You do not have permission to perform this action.'}, status=403)
+            return func(request, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/src/grimoirelab/core/scheduler/views.py
+++ b/src/grimoirelab/core/scheduler/views.py
@@ -25,9 +25,11 @@ from .scheduler import (
     schedule_task,
     reschedule_task as scheduler_reschedule_task
 )
+from ..permissions import check_permissions
 
 
 @api_view(['POST'])
+@check_permissions(['tasks.add_eventizertask'])
 def add_task(request):
     """Create a Task to fetch items
 
@@ -76,6 +78,7 @@ def add_task(request):
 
 
 @api_view(['POST'])
+@check_permissions(['tasks.change_eventizertask'])
 def reschedule_task(request):
     """Reschedule a Task
 
@@ -97,6 +100,7 @@ def reschedule_task(request):
 
 
 @api_view(['POST'])
+@check_permissions(['tasks.delete_eventizertask'])
 def cancel_task(request):
     """Cancel a Task
 

--- a/src/grimoirelab/core/views.py
+++ b/src/grimoirelab/core/views.py
@@ -46,5 +46,6 @@ def api_login(request):
         response = {
             'user': username,
             'isAdmin': user.is_superuser,
+            'groups': [group['name'] for group in user.groups.values('name')]
         }
         return Response(response)


### PR DESCRIPTION
This PR allows defining permission groups to manage the platform.

By default, three permission groups are available: admin, user, and readonly. Admins and users can create and update tasks and repositories, while readonly users have view-only access.

A new command is available. `grimoirelab admin set-permissions <username> <permission_group>` allows assigning a specific permission group to a user.

To add custom groups or adjust permissions, create a new JSON file based on 
 `grimoirelab/core/settings/permissions_groups.json`, and set the environment variable 
 `GRIMOIRELAB_PERMISSION_GROUPS_LIST_PATH` to the path of the new file.